### PR TITLE
Use XS font token in CSS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ids-css",
-  "version": "1.4.0-beta.0",
+  "version": "1.4.0-beta.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -5325,9 +5325,9 @@
       "dev": true
     },
     "ids-identity": {
-      "version": "2.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/ids-identity/-/ids-identity-2.0.0-beta.2.tgz",
-      "integrity": "sha512-9CYV31RGMUCEgHSFqpnnGUomPs9RIgsmmFT6RW6jCE4vo5Zk66EkobMshczsC8hbEFctcNkywomEsLnGUEen9w==",
+      "version": "2.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/ids-identity/-/ids-identity-2.0.0-beta.3.tgz",
+      "integrity": "sha512-Qf5vjpMrMr+bULn+dE8wDNH5zcu2xU1QInWwAVm+qQbvSQLHuasWHWYW4u9NQVv4cBcJ32wR7/HernEZWEQXOw==",
       "dev": true
     },
     "ignore": {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "handlebars": "^4.0.12",
     "handlebars-registrar": "^1.5.2",
     "highlight.js": "^9.12.0",
-    "ids-identity": "^2.0.0-beta.2",
+    "ids-identity": "^2.0.0-beta.3",
     "lost": "^8.3.0",
     "markdownlint-cli": "^0.10.0",
     "marked": "^0.3.19",

--- a/src/packages/ids-formcontrol/ids-formcontrol.css
+++ b/src/packages/ids-formcontrol/ids-formcontrol.css
@@ -90,7 +90,7 @@ select.ids-form-control {
   & > legend,
   & .ids-info-block {
     display: block;
-    font-size: var(--theme-size-font-sm);
+    font-size: var(--theme-size-font-xs);
     line-height: 1.3rem;
   }
 

--- a/src/packages/ids-typography/ids-typography.css
+++ b/src/packages/ids-typography/ids-typography.css
@@ -103,7 +103,7 @@ em,
 
 small,
 .ids-text--small {
-  font-size: var(--theme-size-font-sm);
+  font-size: var(--theme-size-font-xs);
   font-weight: var(--theme-number-font-weight-base);
 }
 
@@ -202,7 +202,7 @@ ol {
 code,
 pre {
   font-family: var(--theme-font-family-monospace);
-  font-size: calc(var(--theme-size-font-sm) - 0.2rem);
+  font-size: var(--theme-size-font-xs);
   line-height: var(--theme-size-line-height-base);
 }
 
@@ -241,7 +241,7 @@ kbd {
   color: #444d56;
   display: inline-block;
   font-family: var(--theme-font-family-monospace);
-  font-size: var(--theme-size-font-sm);
+  font-size: var(--theme-size-font-xs);
   line-height: 10px;
   padding: 5px 8px;
   vertical-align: middle;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Use `theme-size-font-xs` token for labels

**Related github/jira issue (required)**:

https://github.com/infor-design/design-system/pull/228
